### PR TITLE
Changed .recipe-list-item img css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -52,8 +52,8 @@ h1 {
     flex: 1;
 
     img {
-        max-width: 100%;
-        max-height: 100%;
+        width: 100%;
+        height: auto;
     }
 }
 


### PR DESCRIPTION
 from max-width and max-height at 100% to width: 100% and height: auto to stop text from wrapping once images are stretched past their original sizes